### PR TITLE
Added snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ speedtest_exporter
 *.swp
 *.swo
 *.swn
+
+# Snap
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: speedtest-exporter
+base: core18
+version: git
+summary: A Prometheus exporter for measuring Internet connection bandwidth
+description: |
+    speedtest_exporter uses the speedtest.net network of bandwidth measurement
+    servers to measure download and upload bandwidth of an Internet connection
+    at a specific point in time, providing this information to Prometheus.
+
+grade: stable
+confinement: strict
+
+apps:
+  daemon:
+    plugs:
+      - network
+      - network-bind
+    command: speedtest_exporter
+    daemon: simple
+
+parts:
+  speedtest-exporter:
+    plugin: go
+    source: .


### PR DESCRIPTION
This PR adds the required metadata to the repository for this exporter to be built and run as a Snap package. This makes it very easy to install on multiple distributions of Linux, and also means that automated builds can be made available on the snap store (snapcraft.io) if this project is registered there and pointed at the GitHub repository.