### PR TITLE
Fix: log.Infof format test error

### DIFF
--- a/speedtest/client.go
+++ b/speedtest/client.go
@@ -74,7 +74,7 @@ func NewClient(configURL string, serversURL string) (*Client, error) {
 	closestServers := stClient.GetClosestServers(allServers)
 	// log.Infof("Closest Servers: %s", closestServers)
 	testServer := stClient.GetFastestServer(closestServers)
-	log.Infof("Test server: %s", testServer)
+	log.Infof("Test server: %v", testServer)
 
 	return &Client{
 		Server:          testServer,
@@ -101,6 +101,6 @@ func (client *Client) NetworkMetrics() map[string]float64 {
 	result["download"] = downloadMbps
 	result["upload"] = uploadMbps
 	result["ping"] = ping
-	log.Infof("Speedtest results: %s", result)
+	log.Infof("Speedtest results: %v", result)
 	return result
 }


### PR DESCRIPTION
im trying to release the really nice speedtest_exporter for alpine linux. i found this error on running `make test`. i changed the format string to take `%v` instead of `%s`.
```
[speedtest_exporter] Launch unit tests
?       github.com/nlamirault/speedtest_exporter/version        [no test files]
# github.com/nlamirault/speedtest_exporter/speedtest
speedtest/client.go:77:2: Infof format %s has arg testServer of wrong type github.com/zpeters/speedtest/sthttp.Server
speedtest/client.go:104:2: Infof format %s has arg result of wrong type map[string]float64
testing: warning: no tests to run
PASS
ok      github.com/nlamirault/speedtest_exporter        (cached) [no tests to run]
make: *** [Makefile:92: test] Error 2
```